### PR TITLE
Feature/update example

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,7 @@
 {
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "printWidth": 120,
   "singleQuote": true,
-  "semi": false
+  "useTabs": false
 }

--- a/README.md
+++ b/README.md
@@ -4,16 +4,22 @@ This example showcases embedding Ready Player Me avatar creator as an `iframe` t
 
 More details can be found at [web integration guides](https://docs.readyplayer.me/integration-guides/web).
 
+[![Ready Player Me - example-iframe](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/readyplayerme-example-iframe-3pomy?initialpath=/src/iframe.html)
+
 ---
 
 ## About Ready Player Me
+
 [Ready Player Me](https://readyplayer.me/developers) is a cross-app avatar platform for the metaverse used by 1,000+ companies.
 
 ### Getting Started
+
 [Read the documentation](https://docs.readyplayer.me) to get started with integrating Ready Player Me or explore the examples.
 
 ### Add Ready Player Me avatars to your app or game
+
 Do you want to add Ready Player Me avatars to your own app or game? [Learn how to become a Partner](https://docs.readyplayer.me/for-partners/become-a-partner).
 
 ### Community
+
 Get in touch with the Ready Player Me community over at our [Discord](https://discord.gg/readyplayerme).

--- a/src/iframe.html
+++ b/src/iframe.html
@@ -46,31 +46,16 @@
     <input type="button" value="Open Ready Player Me" onClick="displayIframe()" />
     <p id="avatarUrl">Avatar URL:</p>
 
-    <iframe
-      id="frame"
-      class="frame"
-      allow="camera *; microphone *"
-      src="https://demo.readyplayer.me/"
-      hidden="true"
-    ></iframe>
+    <iframe id="frame" class="frame" allow="camera *; microphone *"></iframe>
 
     <script>
+      const subdomain = 'demo'; // Replace with your custom subdomain
       const frame = document.getElementById('frame');
+
+      frame.src = `https://${subdomain}.readyplayer.me/avatar?frameApi`;
 
       window.addEventListener('message', subscribe);
       document.addEventListener('message', subscribe);
-
-      // Subscribe to all events sent from Ready Player Me
-      frame.onload = () => {
-        frame.contentWindow.postMessage(
-          JSON.stringify({
-            target: 'readyplayerme',
-            type: 'subscribe',
-            eventName: 'v1.**'
-          }),
-          '*'
-        );
-      };
 
       function subscribe(event) {
         const json = parse(event);
@@ -79,11 +64,28 @@
           return;
         }
 
+        // Susbribe to all events sent from Ready Player Me once frame is ready
+        if (json.eventName === 'v1.frame.ready') {
+          frame.contentWindow.postMessage(
+            JSON.stringify({
+              target: 'readyplayerme',
+              type: 'subscribe',
+              eventName: 'v1.**'
+            }),
+            '*'
+          );
+        }
+
         // Get avatar GLB URL
         if (json.eventName === 'v1.avatar.exported') {
           console.log(`Avatar URL: ${json.data.url}`);
           document.getElementById('avatarUrl').innerHTML = `Avatar URL: ${json.data.url}`;
           document.getElementById('frame').hidden = true;
+        }
+
+        // Get user id
+        if (json.eventName === 'v1.user.set') {
+          console.log(`User with id ${json.data.id} set: ${JSON.stringify(json)}`);
         }
       }
 

--- a/src/iframe.html
+++ b/src/iframe.html
@@ -1,93 +1,103 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Document</title>
     <style>
-      .container {
-        margin-top: 100px;
-        margin: auto;
-      }
-
-      .content {
-        margin-top: 10px;
+      html,
+      body,
+      .frame {
+        width: 1080px;
+        height: 800px;
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans,
+          Droid Sans, Helvetica Neue, sans-serif;
+        padding: 20px;
+        font-size: 14px;
         border: none;
-        width: 100%;
-        height: calc(100%);
       }
-
-      #avatarUrl {
-        margin-top: 10px;
-      }
-
-      body {
-        padding: 20 40;
-        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-          Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-        background-color: rgb(243, 243, 243);
-      }
-
       .warning {
-        color: rgb(215, 0, 0);
-        font-weight: bold;
+        background-color: #df68a2;
+        padding: 3px;
+        border-radius: 5px;
+        color: white;
       }
     </style>
-
-    <script>
-      // Listen to messages from the iframe
-      window.addEventListener('message', receiveMessage, false)
-
-      // Handle messages from the iframe
-      function receiveMessage(event) {
-        // Check if the received message is a string and a glb url
-        // if not ignore it, and print details to the console
-        if (
-          typeof event.data === 'string' &&
-          event.data.startsWith('https://') &&
-          event.data.endsWith('.glb')
-        ) {
-          const url = event.data
-
-          console.log(`Avatar URL: ${url}`)
-
-          document.getElementById('avatarUrl').innerHTML = `Avatar URL: ${url}`
-          document.getElementById('iframe').hidden = true
-        } else {
-          console.log(`Received message from unknown source: ${event.data}`)
-        }
-      }
-
-      function displayIframe() {
-        document.getElementById('avatarUrl').innerHTML = 'Avatar URL:'
-        document.getElementById('iframe').hidden = false
-      }
-    </script>
   </head>
 
   <body>
     <h2>Ready Player Me iframe example</h2>
     <ul>
       <li>Click "Open Ready Player Me" button.</li>
-      <li>Create an avatar.</li>
-      <li>Click on "Done" button when you finish customizing your avatar.</li>
-      <li>This page will receive the url when it is created.</li>
-      <li>Url will be displayed, and Ready Player Me window will be closed.</li>
+      <li>Create an avatar and hit the "Done" button when you're finished customizing your avatar.</li>
+      <li>This parent page will receive the url to the avatar when it is created.</li>
+      <li>URL will be displayed, and Ready Player Me window will be closed.</li>
     </ul>
     <p class="warning">
-      If you are a Ready Player Me partner, don't forget to replace 'demo' in
-      the iframe source url with your partner subdomain.
+      If you are a Ready Player Me partner, don't forget to replace 'demo' in the iframe source url with your partner
+      subdomain.
     </p>
-    <input
-      type="button"
-      value="Open Ready Player Me"
-      onClick="displayIframe()"
-    />
-    <div id="avatarUrl"><b>Avatar URL: </b></div>
-    <div class="container">
-      <iframe
-        id="iframe"
-        class="content"
-        allow="camera *; microphone *"
-        src="https://demo.readyplayer.me/"
-        hidden="true"
-      ></iframe>
-    </div>
+
+    <input type="button" value="Open Ready Player Me" onClick="displayIframe()" />
+    <p id="avatarUrl">Avatar URL:</p>
+
+    <iframe
+      id="frame"
+      class="frame"
+      allow="camera *; microphone *"
+      src="https://demo.readyplayer.me/"
+      hidden="true"
+    ></iframe>
+
+    <script>
+      const frame = document.getElementById('frame');
+
+      window.addEventListener('message', subscribe);
+      document.addEventListener('message', subscribe);
+
+      // Subscribe to all events sent from Ready Player Me
+      frame.onload = () => {
+        frame.contentWindow.postMessage(
+          JSON.stringify({
+            target: 'readyplayerme',
+            type: 'subscribe',
+            eventName: 'v1.**'
+          }),
+          '*'
+        );
+      };
+
+      function subscribe(event) {
+        const json = parse(event);
+
+        if (json?.source !== 'readyplayerme') {
+          return;
+        }
+
+        // Get avatar GLB URL
+        if (json.eventName === 'v1.avatar.exported') {
+          console.log(`Avatar URL: ${json.data.url}`);
+          document.getElementById('avatarUrl').innerHTML = `Avatar URL: ${json.data.url}`;
+          document.getElementById('frame').hidden = true;
+        }
+      }
+
+      function parse(event) {
+        try {
+          return JSON.parse(event.data);
+        } catch (error) {
+          return null;
+        }
+      }
+
+      function displayIframe() {
+        document.getElementById('frame').hidden = false;
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
- Require `?frameApi` param 
- Added a minimal example of getting an avatar URL with the new subscription interface. A comprehensive list of events will be added to the docs
- Added a link to "Edit on CodeSandbox" to the readme. The sandbox will stay in sync with develop branch
- Removed old message from the example as we expect the subscription interface to be the main way to get events. Of course old message is still emitted to integrations, but everyone can already migrate to the sub interface independently/at their convenience